### PR TITLE
fix: remove default shutdown event

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -66,7 +66,7 @@ func NewPool(options ...ProviderOptionFunc) func(contract.Dispatcher) *Pool {
 			concurrency:    10,
 			timeout:        10 * time.Second,
 			dispatcher:     dispatcher,
-			shutdownEvents: []interface{}{core.OnHTTPServerShutdown, core.OnGRPCServerShutdown},
+			shutdownEvents: []interface{}{},
 		}
 		for _, f := range options {
 			f(&pool)

--- a/pool.go
+++ b/pool.go
@@ -47,7 +47,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/DoNewsCode/core"
 	"github.com/DoNewsCode/core/contract"
 	"github.com/DoNewsCode/core/events"
 	"github.com/oklog/run"


### PR DESCRIPTION
The original default shutdown event is tightly coupled to HTTP and gRPC servers. If one of any servers is missing, goroutines will be leaked. This PR removes the 
 default shutdown events. These events can be added by using the WithShutdownEvents option. 

BREAKING CHANGE